### PR TITLE
fix(pageSize): Missing page size variable passing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/gatsby-plugin-drive",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "index.js",
   "license": "MIT",
   "author": "Fabian Schultz <desk@fabianschultz.com>",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -34,14 +34,14 @@ exports.onPreBootstrap = (
 
     // Start downloading recursively through all folders.
     console.time(`Downloading content`);
-    recursiveFolders(cmsFiles, undefined, token, destination).then(() => {
+    recursiveFolders(cmsFiles, undefined, token, destination, pageSize).then(() => {
       console.timeEnd(`Downloading content`);
       resolve();
     });
   });
 };
 
-function recursiveFolders(array, parent = '', token, destination) {
+function recursiveFolders(array, parent = '', token, destination, pageSize) {
   return new Promise(async (resolve, reject) => {
     let promises = [];
     let filesToDownload = shouldExportGDocs
@@ -58,7 +58,7 @@ function recursiveFolders(array, parent = '', token, destination) {
         // Then, get the files inside and run the function again.
         const files = await googleapi.getFolder(file.id, token, pageSize);
         promises.push(
-          recursiveFolders(files, `${parent}/${file.name}`, token, destination)
+          recursiveFolders(files, `${parent}/${file.name}`, token, destination, pageSize)
         );
       } else {
         promises.push(


### PR DESCRIPTION
Plugin throws error when the destionation folder contains recursive folders bevause pageSize is not passing as argument to the recursiveFolder function.

```success Compiling Gatsby Functions - 0.108s


🚗  Started downloading content


🚗  Creating folder /cakes

 ERROR

pageSize is not defined



  ReferenceError: pageSize is not defined

  - gatsby-node.js:50
    [cukoreka]/[@fs]/gatsby-plugin-drive/gatsby-node.js:50:65

  - new Promise

  - gatsby-node.js:38 recursiveFolders
    [cukoreka]/[@fs]/gatsby-plugin-drive/gatsby-node.js:38:10

  - gatsby-node.js:30
    [cukoreka]/[@fs]/gatsby-plugin-drive/gatsby-node.js:30:5

  - task_queues:96 processTicksAndRejections
    node:internal/process/task_queues:96:5


not finished onPreBootstrap - 0.698s```